### PR TITLE
include boot events 

### DIFF
--- a/coswid-rim-extension.cddl
+++ b/coswid-rim-extension.cddl
@@ -14,8 +14,20 @@ reference-measurement-entry = {
   ? firmware-manufacturer-name => text,
   ? firmware-model-name => text,
   ? firmware-version => uint,
+  ? boot-events => [* boot-event-entry]
   rim-link-hash => bytes,
 }
+
+boot-event-entry = (
+   event-number: uint,
+   event-type: uint,
+   digest-list: [1* hash-entry],
+   event-data: bytes
+)
+hash-entry = [ 
+  hash-alg-id: int,
+  hash-value: bytes,
+]
 
 $$payload-extension //= ( ? support-rim-type-kramdown => direct / indirect, )
 $$payload-extension //= ( ? support-rim-format => text, )
@@ -42,6 +54,7 @@ support-rim-type-kramdown = 74
 support-rim-format = 75
 support-rim-uri-global = 76
 rim-reference = 77
+boot-events = 78
 
 direct = 0
 indirect = 1

--- a/draft-birkholz-rats-coswid-rim.md
+++ b/draft-birkholz-rats-coswid-rim.md
@@ -49,6 +49,16 @@ author:
   region: Maryland
   code: '20877'
   country: USA
+- ins: S. Bhandari
+  name: Shwetha Bhandari
+  org: Cisco Systems, Inc.
+  abbrev: Cisco
+  email: shwethab@cisco.com
+  street: Cessna Business Park, Sarjapura Marathalli Outer Ring Road
+  city: Bangalore
+  region: KARNATAKA
+  code: '560087'
+  country: India
 
 normative:
   RFC2119:
@@ -124,6 +134,7 @@ The design of the additional RIM attributes in this section is motivated by the 
 | firmware-manufacturer-name | 0-1 | An identifier that is represented as the name of a platform manufacturer via a text (tstr) value that SHOULD be included in a CoSWID RIM that covers firmware.
 | firmware-model-name | 0-1 | An identifier that represents the target platform model via a text (tstr) value that SHOULD be included in a CoSWID RIM.
 | firmware-version | 0-1 | An identifier that is represented as the version number of a specific firmware version corresponding to a given set of platform identifiers and SHOULD be included in a CoSWID RIM.
+| boot-events | 0-1 | A reference to the platform measured boot event logs that can be compared to individual events from the platform measured boot events collected at platform runtime.
 
 ## RIM extension for Software Package Management
 


### PR DESCRIPTION
include boot events - to cover secure boot keys, and all other artifacts in measured boot 